### PR TITLE
Delete fb_ddraw.cpp reference in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,7 +306,6 @@ endif( NOT DYN_FLUIDSYNTH )
 # Start defining source files for ZDoom
 set( PLAT_WIN32_SOURCES
 	win32/eaxedit.cpp
-	win32/fb_ddraw.cpp
 	win32/hardware.cpp
 	win32/helperthread.cpp
 	win32/i_cd.cpp


### PR DESCRIPTION
There was a ddraw leftover in CMakeLists.txt, preventing creation of Makefile.